### PR TITLE
Fix: the ability to use a custom button via buttonRef prop was broken.

### DIFF
--- a/src/components/emoji-picker-button.js
+++ b/src/components/emoji-picker-button.js
@@ -15,21 +15,27 @@ import React, { useEffect, useRef, useState } from "react";
  * @return {JSX.Element}
  */
 function EmojiPickerButton({ showPicker, toggleShowPicker, buttonElement, buttonRef }) {
-  
+  const [typeButton, setTypeButton] = useState(/** @type {"OWN" | "REF" | "CUSTOM_CONTENT" | "IDLE"} */ "IDLE");
   const localButtonRef = useRef(null);
-  const [showCustomButtonContent, setShowCustomButtonContent] = useState(false);
 
   useEffect(() => {
-    if ((buttonRef?.current?.childNodes?.length ?? 0) > 2) {
-      localButtonRef.current.appendChild(buttonRef.current.childNodes[0]);
-      setShowCustomButtonContent(true);
-    } else if ((buttonElement?.childNodes?.length ?? 0) > 2) {
-      localButtonRef.current.appendChild(buttonElement?.childNodes[0]);
-      setShowCustomButtonContent(true);
+    if (!buttonRef && !buttonElement) {
+      setTypeButton("OWN");
+      return;
     }
-  }, [buttonElement?.childNodes]);
 
-  return (
+    if (buttonRef && buttonRef.current) {
+      buttonRef.current.addEventListener("click", toggleShowPicker);
+      setTypeButton("REF");
+      return () => buttonRef.current.removeEventListener("click", toggleShowPicker);
+    }
+    else if ((buttonElement?.childNodes?.length ?? 0) >= 2) {
+      localButtonRef.current.appendChild(buttonElement?.childNodes[0]);
+      setTypeButton("CUSTOM_CONTENT");
+    }
+  }, [buttonRef, buttonElement, buttonElement?.childNodes])
+
+  return ( typeButton !== "IDLE" && typeButton !== "REF" &&
     <button
       ref={localButtonRef}
       type="button"
@@ -38,7 +44,7 @@ function EmojiPickerButton({ showPicker, toggleShowPicker, buttonElement, button
       }`}
       onClick={toggleShowPicker}
     >
-      {!showCustomButtonContent && (
+      {typeButton === "OWN" && (
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"

--- a/src/components/emoji-picker-button.js
+++ b/src/components/emoji-picker-button.js
@@ -27,7 +27,10 @@ function EmojiPickerButton({ showPicker, toggleShowPicker, buttonElement, button
     if (buttonRef && buttonRef.current) {
       buttonRef.current.addEventListener("click", toggleShowPicker);
       setTypeButton("REF");
-      return () => buttonRef.current.removeEventListener("click", toggleShowPicker);
+      return () => {
+        if (!buttonRef.current) return;
+        return buttonRef.current.removeEventListener("click", toggleShowPicker);
+      }
     }
     else if ((buttonElement?.childNodes?.length ?? 0) >= 2) {
       localButtonRef.current.appendChild(buttonElement?.childNodes[0]);

--- a/src/components/emoji-picker-wrapper.js
+++ b/src/components/emoji-picker-wrapper.js
@@ -106,7 +106,6 @@ const EmojiPickerWrapper = props => {
   }
 
   /**
-   * 
    * @param {React.MouseEvent} event
    * @return {'above' | 'below'}
    */
@@ -150,26 +149,23 @@ const EmojiPickerWrapper = props => {
   }, [buttonRef, buttonElement]);
 
   return customButton ? (
-    (ReactDOM.createPortal(
-      <>
-        <EmojiPickerContainer
-          showPicker={showPicker}
-          theme={theme}
-          handleSelectEmoji={handleSelectEmoji}
-          disableRecent={disableRecent}
-          customEmojis={customEmojis}
-          position={emojiPickerPosition}
-          language={language}
-        />
-        <EmojiPickerButton
-          showPicker={showPicker}
-          toggleShowPicker={toggleShowPicker}
-          buttonElement={customButton}
-          buttonRef={buttonRef}
-        />
-      </>,
-      customButton
-    ))
+    <>
+      <EmojiPickerContainer
+        showPicker={showPicker}
+        theme={theme}
+        handleSelectEmoji={handleSelectEmoji}
+        disableRecent={disableRecent}
+        customEmojis={customEmojis}
+        position={emojiPickerPosition}
+        language={language}
+      />
+      <EmojiPickerButton
+        showPicker={showPicker}
+        toggleShowPicker={toggleShowPicker}
+        buttonElement={customButton}
+        buttonRef={buttonRef}
+      />
+    </>
   ) : (
     (<>
       <EmojiPickerContainer


### PR DESCRIPTION
It was impossible to use custom buttonRef.
Moreover, the buttonRef has been combined with the EmojiPicker component in the React.portal. And now, we have two components independent of each other.

If any changes are required, I will be happy to make them.